### PR TITLE
Don't overwrite base path when constructing paths

### DIFF
--- a/src/clients/jellyfin/jellyfin.stream.builder.service.ts
+++ b/src/clients/jellyfin/jellyfin.stream.builder.service.ts
@@ -18,7 +18,7 @@ export class JellyfinStreamBuilderService {
     const accessToken = this.jellyfinService.getApi().accessToken;
 
     const uri = new URL(api.basePath);
-    uri.pathname = `/Audio/${jellyfinItemId}/universal`;
+    uri.pathname += `/Audio/${jellyfinItemId}/universal`;
     uri.searchParams.set('UserId', this.jellyfinService.getUserId());
     uri.searchParams.set(
       'DeviceId',

--- a/src/clients/jellyfin/jellyfin.websocket.service.ts
+++ b/src/clients/jellyfin/jellyfin.websocket.service.ts
@@ -154,7 +154,7 @@ export class JellyfinWebSocketService implements OnModuleDestroy {
 
   private buildSocketUrl(baseName: string, apiToken: string, device: string) {
     const url = new URL(baseName);
-    url.pathname = '/socket';
+    url.pathname += '/socket';
     url.protocol = url.protocol.replace('http', 'ws');
     url.search = `?api_key=${apiToken}&deviceId=${device}`;
     return url;


### PR DESCRIPTION
Fix the WebSocketService to not overwrite Jellyfin's base path when constructing a url for the websockets.
Additionally, fix the JellyfinStreamBuilder to not do the same thing for streaming URLs.
Fixes #64 and #238.