### PR TITLE
Fix playing albums and playlists

### DIFF
--- a/src/models/search/AlbumSearchItem.ts
+++ b/src/models/search/AlbumSearchItem.ts
@@ -1,4 +1,4 @@
-import { SearchHint as JellyfinSearchHint } from '@jellyfin/sdk/lib/generated-client/models';
+import { BaseItemDto, SearchHint as JellyfinSearchHint } from '@jellyfin/sdk/lib/generated-client/models';
 
 import { Track } from '../music/Track';
 import { JellyfinSearchService } from '../../clients/jellyfin/jellyfin.search.service';
@@ -26,6 +26,24 @@ export class AlbumSearchItem extends SearchItem {
       hint.Id,
       trimStringToFixedLength(artist + hint.Name, 70),
       hint.RunTimeTicks / 10000,
+    );
+  }
+
+  static constructFromBaseItem(baseItem: BaseItemDto) {
+    if (baseItem.Id === undefined || !baseItem.Name || !baseItem.RunTimeTicks) {
+      throw new Error(
+        'Unable to construct search hint from base item, required properties were undefined',
+      );
+    }
+    var artist = ""
+    if(baseItem.AlbumArtist) {
+    	artist = baseItem.AlbumArtist + " - "
+    }
+
+    return new AlbumSearchItem(
+      baseItem.Id,
+      trimStringToFixedLength(artist + baseItem.Name, 70),
+      baseItem.RunTimeTicks / 10000,
     );
   }
 

--- a/src/models/search/PlaylistSearchItem.ts
+++ b/src/models/search/PlaylistSearchItem.ts
@@ -1,4 +1,4 @@
-import { SearchHint as JellyfinSearchHint } from '@jellyfin/sdk/lib/generated-client/models';
+import { BaseItemDto, SearchHint as JellyfinSearchHint } from '@jellyfin/sdk/lib/generated-client/models';
 
 import { Track } from '../music/Track';
 import { JellyfinSearchService } from '../../clients/jellyfin/jellyfin.search.service';
@@ -23,6 +23,20 @@ export class PlaylistSearchItem extends SearchItem {
       hint.Id,
       trimStringToFixedLength(hint.Name, 50),
       hint.RunTimeTicks / 10000,
+    );
+  }
+  
+  static constructFromBaseItem(baseItem: BaseItemDto) {
+    if (baseItem.Id === undefined || !baseItem.Name || !baseItem.RunTimeTicks) {
+      throw new Error(
+        'Unable to construct playlist search hint, required properties were undefined',
+      );
+    }
+
+    return new PlaylistSearchItem(
+      baseItem.Id,
+      trimStringToFixedLength(baseItem.Name, 50),
+      baseItem.RunTimeTicks / 10000,
     );
   }
 

--- a/src/utils/trackConverter.ts
+++ b/src/utils/trackConverter.ts
@@ -9,7 +9,7 @@ export const flatMapTrackItems = (
   let tracks: Track[] = [];
   hints.forEach(async (hint) => {
     const searchedTracks = await hint.toTracks(jellyfinSearchService);
-    tracks = [...tracks, ...searchedTracks];
+    searchedTracks.forEach((track) => tracks.push(track));
   });
   return tracks;
 };


### PR DESCRIPTION
When trying to add albums/playlists to the queue, they would get added as singular audio items and wouldn't really play.
This happened because AlbumSearchItem and PlaylistSearchItem didn't have their own constructFromBaseItem implementation and that would trigger the default SearchItem one - making the rest of the logic to treat them as regular audio items.
Additionally, flatMapTrackItems wouldn't really add searchedTracks to returned tracks? No idea what happened with that, all I know is that before the fix, any queued playlist would return with 0 tracks and not really play.

Fixes #182.