### PR TITLE
Fix casting to the bot device

### DIFF
--- a/src/clients/jellyfin/jellyfin.search.service.ts
+++ b/src/clients/jellyfin/jellyfin.search.service.ts
@@ -162,7 +162,7 @@ export class JellyfinSearchService {
       includeItemTypes,
     });
 
-    if (!data.Items || data.Items.length !== 1) {
+    if (!data.Items || data.Items.length === 0) {
       this.logger.warn(`Failed to retrieve item via id '${ids}'`);
       return [];
     }

--- a/src/clients/jellyfin/jellyfin.websocket.service.ts
+++ b/src/clients/jellyfin/jellyfin.websocket.service.ts
@@ -105,7 +105,7 @@ export class JellyfinWebSocketService implements OnModuleDestroy {
           `Processing ${ids.length} ids received via websocket and adding them to the queue`,
         );
         const searchHints = await this.jellyfinSearchService.getAllById(ids);
-        const tracks = flatMapTrackItems(searchHints, this.jellyfinSearchService);
+        const tracks = await flatMapTrackItems(searchHints, this.jellyfinSearchService);
         this.playbackService.getPlaylistOrDefault().enqueueTracks(tracks);
         break;
       case SessionMessageType[SessionMessageType.Playstate]:


### PR DESCRIPTION
flatMapTrackItems is not an async function from what I know, but somehow it was able to return nothing before the conversion was fully done - an await fixes that.
Additionally for casting albums and playlists, a data length check in Jellyfin search service would happily reject anything that has more than one item :)
Fixes #250 