### PR TITLE
Keep a tighter sync between Jellyfin's remote control and the state of the Discord player

### DIFF
--- a/src/clients/discord/discord.voice.service.ts
+++ b/src/clients/discord/discord.voice.service.ts
@@ -129,6 +129,10 @@ export class DiscordVoiceService {
   @OnEvent('internal.voice.controls.pause')
   pause() {
     this.createAndReturnOrGetAudioPlayer().pause();
+    const track = this.playbackService.getPlaylistOrDefault().getActiveTrack();
+    if(track) {
+      track.playing = false;
+    }
     this.eventEmitter.emit('playback.state.pause', true);
   }
 
@@ -137,7 +141,13 @@ export class DiscordVoiceService {
    */
   @OnEvent('internal.voice.controls.stop')
   stop(force: boolean): boolean {
-    return this.createAndReturnOrGetAudioPlayer().stop(force);
+    const hasStopped = this.createAndReturnOrGetAudioPlayer().stop(force);
+    if (hasStopped) {
+      const playlist = this.playbackService.getPlaylistOrDefault();
+      this.eventEmitter.emit('internal.audio.track.finish', playlist.getActiveTrack());
+      playlist.clear();
+    }
+    return hasStopped;
   }
 
   /**
@@ -145,6 +155,10 @@ export class DiscordVoiceService {
    */
   unpause() {
     this.createAndReturnOrGetAudioPlayer().unpause();
+    const track = this.playbackService.getPlaylistOrDefault().getActiveTrack();
+    if(track) {
+      track.playing = true;
+    }
     this.eventEmitter.emit('playback.state.pause', false);
   }
 

--- a/src/clients/jellyfin/jellyfin.playstate.service.ts
+++ b/src/clients/jellyfin/jellyfin.playstate.service.ts
@@ -97,8 +97,8 @@ export class JellyinPlaystateService {
 
   @Interval(1000)
   private async onPlaybackProgress() {
-    const track = this.playbackService.getPlaylistOrDefault().getActiveTrack();
-
+    const playlist = this.playbackService.getPlaylistOrDefault();
+    const track = playlist.getActiveTrack();
     if (!track || !playlist.hasAnyPlaying()) {
       return;
     }

--- a/src/clients/jellyfin/jellyfin.playstate.service.ts
+++ b/src/clients/jellyfin/jellyfin.playstate.service.ts
@@ -99,7 +99,7 @@ export class JellyinPlaystateService {
   private async onPlaybackProgress() {
     const track = this.playbackService.getPlaylistOrDefault().getActiveTrack();
 
-    if (!track) {
+    if (!track || !playlist.hasAnyPlaying()) {
       return;
     }
 

--- a/src/models/music/Playlist.ts
+++ b/src/models/music/Playlist.ts
@@ -140,7 +140,7 @@ export class Playlist {
     this.activeTrackIndex = undefined;
   }
 
-  private hasAnyPlaying() {
+  hasAnyPlaying() {
     return this.tracks.some((track) => track.playing);
   }
 


### PR DESCRIPTION
A follow up to #255. That fixed the casting itself, but pause/stop events from Discord wouldn't get sent back to Jellyfin, making it think that the device was still playing. Furthermore, even if they got sent - they got overwritten by unrelenting updates from onPlaybackProgress().
So added notifying Jellyfin of Discord playstate events and made onPlaybackProgress() only report progress when something on the playlist was actually playing.