### PR TITLE
Listen for Discord disconnect event and make sure it's handled

### DIFF
--- a/src/clients/discord/discord.voice.service.ts
+++ b/src/clients/discord/discord.voice.service.ts
@@ -9,6 +9,7 @@ import {
   joinVoiceChannel,
   NoSubscriberBehavior,
   VoiceConnection,
+  VoiceConnectionStatus,
 } from '@discordjs/voice';
 
 import { Injectable } from '@nestjs/common';
@@ -96,7 +97,12 @@ export class DiscordVoiceService {
     if (this.voiceConnection === undefined) {
       this.voiceConnection = getVoiceConnection(member.guild.id);
     }
-
+    this.voiceConnection?.on(VoiceConnectionStatus.Disconnected, () => {
+      if (this.voiceConnection !== undefined) {
+        const playlist = this.playbackService.getPlaylistOrDefault().clear();
+        this.disconnect();
+      }
+    });
     return {
       success: true,
       reply: {},


### PR DESCRIPTION
Listen for the Disconnected event from Discord side as it might be triggered by us, but also by the server admin manually disconnecting the bot.
In any case, make sure to clear the playlist and properly disconnect the bot to not potentially leave it lingering in a partially connected state.
Fixes #258 