### PR TITLE
Work around discordjs voice api version mismatch

### DIFF
--- a/src/clients/discord/discord.voice.service.ts
+++ b/src/clients/discord/discord.voice.service.ts
@@ -32,6 +32,7 @@ import { JellyfinStreamBuilderService } from '../jellyfin/jellyfin.stream.builde
 import { JellyfinWebSocketService } from '../jellyfin/jellyfin.websocket.service';
 
 import { DiscordMessageService } from './discord.message.service';
+import { DiscordGatewayAdapterCreator } from '@discordjs/voice';
 
 @Injectable()
 export class DiscordVoiceService implements OnModuleDestroy {
@@ -107,7 +108,7 @@ export class DiscordVoiceService implements OnModuleDestroy {
 
     joinVoiceChannel({
       channelId: channel.id,
-      adapterCreator: channel.guild.voiceAdapterCreator,
+      adapterCreator: channel.guild.voiceAdapterCreator as unknown as DiscordGatewayAdapterCreator,
       guildId: channel.guildId,
     });
 


### PR DESCRIPTION
Downloaded a fresh master today and got greeted by this error from the discord voice service client file:
`error TS2322: Type 'InternalDiscordGatewayAdapterCreator' is not assignable to type 'DiscordGatewayAdapterCreator'.
  Types of parameters 'methods' and 'methods' are incompatible.`

According to https://github.com/discordjs/voice/issues/166, this is due to version mismatch between discord-api-types version of discord.js and @discordjs/voice.

A quick fix below.