### PR TITLE
Drop only broken items for broken search results

### DIFF
--- a/src/clients/jellyfin/jellyfin.search.service.ts
+++ b/src/clients/jellyfin/jellyfin.search.service.ts
@@ -62,13 +62,17 @@ export class JellyfinSearchService {
         throw new Error('SearchHints were undefined');
       }
 
-      var SearchItems: SearchItem[] = [];
+      var searchItems: SearchItem[] = [];
       for (let hint of SearchHints) {
         try {
-	 SearchItems.push(this.transformToSearchHintFromHint(hint) as SearchItem) 
-	} catch(err) {}	
+	 searchItems.push(this.transformToSearchHintFromHint(hint) as SearchItem) 
+	} catch(err) {
+          this.logger.warn(
+            `Failed to include an item in the search results for ${searchTerm}: ${hint}`,
+          );
+	}	
       }
-      return SearchItems;
+      return searchItems;
     } catch (err) {
       this.logger.error(`Failed to search on Jellyfin: ${err}`);
       return [];

--- a/src/clients/jellyfin/jellyfin.search.service.ts
+++ b/src/clients/jellyfin/jellyfin.search.service.ts
@@ -65,7 +65,9 @@ export class JellyfinSearchService {
       var searchItems: SearchItem[] = [];
       for (let hint of SearchHints) {
         try {
-	 searchItems.push(this.transformToSearchHintFromHint(hint) as SearchItem) 
+	  let searchItem = this.transformToSearchHintFromHint(hint);
+	  if (searchItem instanceof SearchItem)
+	    searchItems.push(searchItem);
 	} catch(err) {
           this.logger.warn(
             `Failed to include an item in the search results for ${searchTerm}: ${hint}`,

--- a/src/clients/jellyfin/jellyfin.search.service.ts
+++ b/src/clients/jellyfin/jellyfin.search.service.ts
@@ -62,9 +62,13 @@ export class JellyfinSearchService {
         throw new Error('SearchHints were undefined');
       }
 
-      return SearchHints.map((hint) =>
-        this.transformToSearchHintFromHint(hint),
-      ).filter((x) => x !== null) as SearchItem[];
+      var SearchItems: SearchItem[] = [];
+      for (let hint of SearchHints) {
+        try {
+	 SearchItems.push(this.transformToSearchHintFromHint(hint) as SearchItem) 
+	} catch(err) {}	
+      }
+      return SearchItems;
     } catch (err) {
       this.logger.error(`Failed to search on Jellyfin: ${err}`);
       return [];


### PR DESCRIPTION
I recently encountered an issue where some search keywords wouldn't yield any results, even though the songs were in the database. It turned out that my Jellyfin server wouldn't return RuntimeTicks for one specific song, which broke the SearchHints map() and made it throw the entire array of results away.

Switched the map() operation to a loop iteratively adding elements, so we can discard elements if they are broken instead of throwing the entire result array away.