### PR TITLE
Fixed reverse order to albums and playlists.

### DIFF
--- a/src/clients/jellyfin/jellyfin.search.service.ts
+++ b/src/clients/jellyfin/jellyfin.search.service.ts
@@ -116,9 +116,6 @@ export class JellyfinSearchService {
       userId: this.jellyfinService.getUserId(),
       mediaTypes: [BaseItemKind[BaseItemKind.Audio]],
       searchTerm: '%',
-      sortBy: ['IndexNumber'],
-      sortOrder: ['Descending' as any],
-      recursive: true,
     });
 
     if (axiosResponse.status !== 200) {
@@ -135,9 +132,9 @@ export class JellyfinSearchService {
       return [];
     }
 
-    return [...axiosResponse.data.SearchHints]
-      .reverse()
-      .map((hint) => SearchItem.constructFromHint(hint));
+    return [...axiosResponse.data.SearchHints].map((hint) =>
+      SearchItem.constructFromHint(hint),
+    );
   }
 
   async getById(

--- a/src/commands/play/play.command.ts
+++ b/src/commands/play/play.command.ts
@@ -96,9 +96,7 @@ export class PlayItemCommand {
       return;
     }
 
-    const tracks = await (
-      await item.toTracks(this.jellyfinSearchService)
-    ).reverse();
+    const tracks = await item.toTracks(this.jellyfinSearchService);
     this.logger.debug(`Extracted ${tracks.length} tracks from the search item`);
     const reducedDuration = tracks.reduce(
       (sum, item) => sum + item.duration,


### PR DESCRIPTION
#454 
Fix playback order for both playlists and albums without needing to dictate sortby etc. In my notes ".reverse()" in jellyfin.search.service.ts affected albums, and playlists in play.command.ts 